### PR TITLE
Update EventPreview.vue

### DIFF
--- a/components/EventPreview.vue
+++ b/components/EventPreview.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-import isNumber from 'lodash/isNumber';
+import isFinite from 'lodash/isFinite';
 import StaticNoise from '~/components/StaticNoise';
 
 export default {
@@ -42,7 +42,7 @@ export default {
         case 'app.stitcher.com':
           return `https://app.stitcher.com/splayer/f/${url.pathname
             .split('/')
-            .find((seg) => isNumber(parseInt(seg, 10)))}`;
+            .find((seg) => isFinite(parseInt(seg, 10)))}`;
         default:
           return null;
       }


### PR DESCRIPTION
Fixes stitcher preview links for app.stitcher.com entries. Uses `isFinite` which returns false when the value is NaN.