### PR TITLE
Moving loading screen to block only the timetable grid

### DIFF
--- a/components/LoadingScreen.vue
+++ b/components/LoadingScreen.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="font-sans loading-screen flex items-center justify-center fixed inset-0 z-50"
+    class="font-sans loading-screen flex items-center justify-center fixed md:absolute inset-0 z-50"
   >
     <div class="loading" data-text="LOADING">LOADING</div>
     <StaticNoise />

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -30,7 +30,7 @@
           :hours-to-display="hoursToDisplay"
           :selected-event="selectedEvent"
           show-inline-descriptions
-          class="flex-grow w-full"
+          class="absolute inset-0"
           @eventClick="handleEventClick"
         />
       </transition>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,19 +16,25 @@
         <EventDescription :event="selectedEvent" class="description w-1/2" />
       </div>
     </div>
-    <TimeTable
-      :auto-scroll="autoScroll"
-      :infinite-scroll="infiniteScroll"
-      :channels="channels"
-      :events="upcomingEvents"
-      :current-time="currentTime"
-      :start-time="startTime"
-      :hours-to-display="hoursToDisplay"
-      :selected-event="selectedEvent"
-      show-inline-descriptions
-      class="flex-grow w-full"
-      @eventClick="handleEventClick"
-    />
+    <div class="flex-grow overflow-hidden relative">
+      <transition name="slow-fade">
+        <LoadingScreen v-if="isLoading" />
+        <TimeTable
+          v-else
+          :auto-scroll="autoScroll"
+          :infinite-scroll="infiniteScroll"
+          :channels="channels"
+          :events="upcomingEvents"
+          :current-time="currentTime"
+          :start-time="startTime"
+          :hours-to-display="hoursToDisplay"
+          :selected-event="selectedEvent"
+          show-inline-descriptions
+          class="flex-grow w-full"
+          @eventClick="handleEventClick"
+        />
+      </transition>
+    </div>
     <div class="fixed bottom-0 flex items-center right-0 mb-4 mr-8 z-30">
       <FloatingButton
         v-if="infiniteScroll"
@@ -58,9 +64,6 @@
         <span class="relative font-medium text-4xl">+</span>
       </FloatingButton>
     </div>
-    <transition name="slow-fade">
-      <LoadingScreen v-if="isLoading" />
-    </transition>
   </div>
 </template>
 
@@ -215,10 +218,6 @@ export default {
 </style>
 
 <style lang="scss" scoped>
-.time-table {
-  flex-grow: 1;
-}
-
 @media screen and (min-width: 768px) {
   .header {
     height: 60%;


### PR DESCRIPTION
Rather than block the entire screen, this makes the loading screen only cover the timetable grid. This prevents youtube scripts from blocking the loading process and also improves perceived loading time since users have something to look at in the preview panels while the page loads.

Fixes #86.