### PR TITLE
Hide channels with no upcoming events

### DIFF
--- a/components/FloatingButton.vue
+++ b/components/FloatingButton.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="tag"
-    class="focus:outline-none focus:shadow-outline floating-button cursor-pointer appearance-none h-12 inline-flex items-center justify-center rounded-full w-12 transition duration-200 ease-in-out shadow-md"
+    class="floating-button focus:outline-none focus:shadow-outline cursor-pointer appearance-none h-12 inline-flex items-center justify-center rounded-full w-12 transition duration-200 ease-in-out shadow-md"
     :class="{
       'bg-red hover:bg-dark-red text-white': variant === 'primary',
       'bg-gray hover:bg-blue text-blue hover:text-white':

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -112,7 +112,10 @@ export default {
   },
   computed: {
     channels() {
-      return uniq(this.events.map((item) => item.channel))
+      const events = this.upcomingEvents.length
+        ? this.upcomingEvents
+        : this.events;
+      return uniq(events.map((item) => item.channel))
         .filter((item) => item)
         .sort();
     },


### PR DESCRIPTION
Hides channels from view that don't have any upcoming events. Fixes #106. Fixes #103 (set minimum row height for empty channels - this becomes obsolete).