### PR TITLE
Add support for inlining Twitch videos

### DIFF
--- a/components/EventPreview.vue
+++ b/components/EventPreview.vue
@@ -30,6 +30,12 @@ export default {
   computed: {
     embedLink() {
       if (this.event.embedLink) {
+        const url = new URL(this.event.embedLink);
+        // Twitch requires that we include the domain of the embedding parent
+        // window. Add that here.
+        if (url.hostname === 'player.twitch.tv') {
+          return this.event.embedLink + `&parent=${window.location.hostname}`;
+        }
         return this.event.embedLink;
       }
       const url = new URL(this.event.link);
@@ -39,6 +45,11 @@ export default {
           return `https://www.youtube.com/embed/${url.searchParams.get(
             'v'
           )}?autoplay=1&mute=1&rel=0`;
+        case 'www.twitch.tv':
+          // Same issue as above of Twitch requiring the parent window's domain.
+          return `https://player.twitch.tv/?channel=${url.pathname
+            .split('/')
+            .find((seg) => seg)}?parent=${window.location.hostname}`;
         case 'app.stitcher.com':
           return `https://app.stitcher.com/splayer/f/${url.pathname
             .split('/')


### PR DESCRIPTION
This also adds a fix for any Twitch videos that have an `embedLink` from the dataset. Those were failing because Twitch requires we pass along the domain of the embedding iframe as a `parent` param.

![Screen Shot 2020-06-10 at 7 12 11 PM](https://user-images.githubusercontent.com/801206/84338610-5d0c2880-ab51-11ea-8489-deb13b7f257f.png)

Fixes #105.