### PR TITLE
Rework the logic for showing inactive channels

### DIFF
--- a/components/TimeTable.vue
+++ b/components/TimeTable.vue
@@ -257,6 +257,7 @@ $grid-gap: 5px;
 
 .channel {
   @apply bg-black
+    box-content
     flex
     font-bold
     items-center
@@ -269,6 +270,7 @@ $grid-gap: 5px;
     text-white
     uppercase z-20;
   grid-column: channels;
+  min-height: 3em;
 
   // Horizontal grid lines
   &::after {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -112,12 +112,20 @@ export default {
   },
   computed: {
     channels() {
-      const events = this.upcomingEvents.length
-        ? this.upcomingEvents
-        : this.events;
-      return uniq(events.map((item) => item.channel))
-        .filter((item) => item)
-        .sort();
+      // If most channels are active, show only active channels. Otherwise, show
+      // all channels so that the layout isn't empty
+      const activeChannels = uniq(
+        this.upcomingEvents.map((item) => item.channel)
+      ).filter((item) => item);
+      const allChannels = uniq(this.events.map((item) => item.channel)).filter(
+        (item) => item
+      );
+      const channelsToShow = Math.round(
+        activeChannels.length / allChannels.length
+      )
+        ? activeChannels
+        : allChannels;
+      return channelsToShow.sort();
     },
     eventsHappeningNow() {
       const now = new Date();


### PR DESCRIPTION
Shows only active channels when there are more active channels than inactive ones. Otherwise show all channels to avoid weird layouts when there aren't enough active channels to fill up the bottom half of the screen.

Also adds a minimum height for channels to address #103.