### PR TITLE
fix incorrect endtime key

### DIFF
--- a/services/api.js
+++ b/services/api.js
@@ -46,7 +46,7 @@ const mapEntry = (entry) => {
   const startTime = toDate(new Date(startTimeStr + ' EDT'), {
     timeZone: 'America/New_York',
   });
-  const endTimeStr = get(entry, 'gsx$endtime.$t', null);
+  const endTimeStr = get(entry, 'gsx$endtimeoptional.$t', null);
   const duration = durationToMinutes(
     get(entry, 'gsx$durationoptional.$t') || '1:00'
   );


### PR DESCRIPTION
Looks like the spreadsheet column name was renamed from "endtime" to "endtimeoptional". There are a couple 24-hour events today we can use to verify.

![endtimescreenshot](https://user-images.githubusercontent.com/4806609/85930522-ecb01780-b871-11ea-93f4-e66fa1d63d9f.png)
![endtimescreenshot2](https://user-images.githubusercontent.com/4806609/85930523-ed48ae00-b871-11ea-9bb4-452a8ef74566.png)

**Note:** we may want to do something about the display of "start - end time" on the grid cells when the event spans into the next day. Seeing "7:00 AM - 7:00 AM" or something like "10:00 AM - 6:00 AM" might be confusing without the different dates shown.