### PR TITLE
Feature/show latest youtube upload

### DIFF
--- a/services/youtubeApi.js
+++ b/services/youtubeApi.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import get from 'lodash/get';
 
 const apiKey = process.env.GOOGLE_API_KEY;
-const baseURL = 'https://www.googleapis.com/youtube/v3/videos';
+const baseURL = 'https://www.googleapis.com/youtube/v3';
 const headers = {
   'X-Requested-With': 'XMLHttpRequest',
   'Content-Type': 'application/json',
@@ -13,13 +13,35 @@ const api = axios.create({
   headers,
 });
 
+export const fetchChannelLatestUploads = async (channelUsername) => {
+  const { data } = await api.get(
+    `/channels?key=${apiKey}&part=contentDetails&forUsername=${channelUsername}`
+  );
+  return data;
+};
+
+const BOSTON_GLOBE_UPLOADS_PLAYLIST = 'UUcNkwfTQuXAxAFwoAUHweJA';
+export const fetchLatestPlaylistVideos = async (
+  playlistId = BOSTON_GLOBE_UPLOADS_PLAYLIST,
+  maxResults = 1
+) => {
+  const { data } = await api.get(
+    `/playlistItems?key=${apiKey}&playlistId=${playlistId}` +
+      `&maxResults=${maxResults}&part=snippet,contentDetails` +
+      `&fields=items(contentDetails(videoId),snippet(description,title))`
+  );
+  return get(data, 'items', []);
+};
+
 export const fetchEmbeddableStatus = async (videoId) => {
   const { data } = await api.get(
-    `?id=${videoId}&key=${apiKey}&part=status&fields=items(status(embeddable))`
+    `/videos?id=${videoId}&key=${apiKey}&part=status&fields=items(status(embeddable))`
   );
   return get(data, 'items.0.status.embeddable', false);
 };
 
 export default {
+  fetchChannelLatestUploads,
   fetchEmbeddableStatus,
+  fetchLatestPlaylistVideos,
 };

--- a/util/truncateDescription.js
+++ b/util/truncateDescription.js
@@ -1,0 +1,31 @@
+/**
+ * Returns the given description truncated at the first instance of
+ * specific phrases.
+ * @param {description} string
+ * @returns {String}
+ */
+
+const truncateAtPhrases = [
+  'read more at',
+  'like us on',
+  'follow us on',
+  'follow us at',
+];
+
+const truncateDescription = (description) => {
+  const downcasedDescription = description.trim().toLowerCase();
+  const truncateAtIndices = truncateAtPhrases
+    .map((phrase) => {
+      return downcasedDescription.indexOf(phrase);
+    })
+    .filter((idx) => idx > 0);
+
+  if (!truncateAtIndices.length) {
+    return description;
+  }
+
+  const truncateAtIndex = Math.min.apply(Math, truncateAtIndices);
+  return description.slice(0, truncateAtIndex).trim();
+};
+
+export default truncateDescription;


### PR DESCRIPTION
Fixes #109 

- on initial load, attempt to fetch "The Boston Globe" youtube channel upload and display it as first selected event. **Note:** Boston Globe video will be shown first for all the different versions of LiveGuide. Let me know if it shouldn't.
- when displaying latest BG upload, truncate the video description at the first instance of the following phrases:
  - read more at
  - like us on
  - follow us on
  - follow us at